### PR TITLE
Adding CLOUD_LINK environment variable to Jenkins job

### DIFF
--- a/src/main/java/com/testdroid/jenkins/CloudLink.java
+++ b/src/main/java/com/testdroid/jenkins/CloudLink.java
@@ -30,7 +30,7 @@ public class CloudLink implements BuildBadgeAction {
 
     @Override
     public String getIconFileName() {
-        return "cloud.gif";
+        return "/plugin/testdroid-run-in-cloud/images/cloud.gif";
     }
 
     @Override

--- a/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
+++ b/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
@@ -16,10 +16,7 @@ import com.testdroid.jenkins.utils.EmailHelper;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Hudson;
+import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.ListBoxModel;
@@ -456,8 +453,13 @@ public class RunInCloudBuilder extends AbstractBuilder {
                     StringUtils.isNotBlank(descriptor.getNewCloudUrl()) ?
                             descriptor.getNewCloudUrl() : descriptor
                             .getCloudUrl() : TestdroidCloudSettings.CLOUD_ENDPOINT;
-            build.getActions().add(new CloudLink(build, String.format("%s/#service/testrun/%s/%s",
-                    cloudLinkPrefix, testRun.getProjectId(), testRun.getId())));
+            String cloudLink = String.format("%s/#service/testrun/%s/%s", cloudLinkPrefix, testRun.getProjectId(),
+                    testRun.getId());
+            build.getActions().add(new CloudLink(build, cloudLink));
+
+            RunInCloudEnvInject variable = new RunInCloudEnvInject("CLOUD_LINK", cloudLink);
+            build.addAction(variable);
+
 
             plugin.getSemaphore().release();
             releaseDone = true;

--- a/src/main/java/com/testdroid/jenkins/RunInCloudEnvInject.java
+++ b/src/main/java/com/testdroid/jenkins/RunInCloudEnvInject.java
@@ -1,0 +1,39 @@
+package com.testdroid.jenkins;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.EnvironmentContributingAction;
+
+/**
+ * Created by rogerio.c.peixoto on 4/28/16.
+ */
+public class RunInCloudEnvInject implements EnvironmentContributingAction {
+
+    private String key;
+
+    private String value;
+
+    public RunInCloudEnvInject(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    @Override public void buildEnvVars(AbstractBuild<?, ?> abstractBuild, EnvVars envVars) {
+        if (envVars != null && key != null && value != null) {
+            envVars.put(key, value);
+        }
+    }
+
+    @Override public String getIconFileName() {
+        return null;
+    }
+
+    @Override public String getDisplayName() {
+        return "RunInCloudBuilderEnvInjectionAction";
+    }
+
+    @Override public String getUrlName() {
+        return null;
+    }
+}
+

--- a/src/main/resources/com/testdroid/jenkins/CloudLink/badge.jelly
+++ b/src/main/resources/com/testdroid/jenkins/CloudLink/badge.jelly
@@ -3,7 +3,7 @@
         <a href="${it.getUrlName()}">
             <img width="16" height="16"
                  title="${it.getDisplayName()}"
-                 src="${rootURL}/plugin/testdroid-run-in-cloud/images/${it.getIconFileName()}"/>
+                 src="${it.getIconFileName()}"/>
         </a>
     </j:if>
 </j:jelly>


### PR DESCRIPTION
Adding the CLOUD_LINK environment variable that will hold the test's result URL in order to use it in Slack notifications.
I also fixed the job details side panel icon for the 'See detailed results in Testdroid Cloud' option, It was not loading properly before.