### PR TITLE
Separate the device language and country code with an underscore

### DIFF
--- a/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
+++ b/src/main/java/com/testdroid/jenkins/RunInCloudBuilder.java
@@ -14,6 +14,7 @@ import com.testdroid.jenkins.scheduler.TestRunFinishCheckScheduler;
 import com.testdroid.jenkins.scheduler.TestRunFinishCheckSchedulerFactory;
 import com.testdroid.jenkins.utils.AndroidLocale;
 import com.testdroid.jenkins.utils.EmailHelper;
+import com.testdroid.jenkins.utils.LocaleUtil;
 import com.testdroid.jenkins.utils.TestdroidApiUtil;
 import hudson.Extension;
 import hudson.FilePath;
@@ -233,7 +234,11 @@ public class RunInCloudBuilder extends AbstractBuilder {
 
     public String getLanguage() {
         if (StringUtils.isBlank(language)) {
-            language = String.format("%s-%s", Locale.US.getLanguage(), Locale.US.getCountry());
+            language = LocaleUtil.formatLangCode(Locale.US);
+        }
+        // handle old versions' configs with wrongly formatted language codes
+        if (language.contains("-")) {
+            language = language.replace('-', '_');
         }
         return language;
     }
@@ -849,7 +854,7 @@ public class RunInCloudBuilder extends AbstractBuilder {
             for (Locale locale : AndroidLocale.LOCALES) {
                 String langDisplay = String.format("%s (%s)", locale.getDisplayLanguage(),
                         locale.getDisplayCountry());
-                String langCode = String.format("%s-%s", locale.getLanguage(), locale.getCountry());
+                String langCode = LocaleUtil.formatLangCode(locale);
                 language.add(langDisplay, langCode);
             }
             return language;

--- a/src/main/java/com/testdroid/jenkins/utils/LocaleUtil.java
+++ b/src/main/java/com/testdroid/jenkins/utils/LocaleUtil.java
@@ -1,0 +1,10 @@
+package com.testdroid.jenkins.utils;
+
+import java.util.Locale;
+
+public class LocaleUtil {
+
+    public static String formatLangCode(Locale locale) {
+        return String.format("%s_%s", locale.getLanguage(), locale.getCountry());
+    }
+}


### PR DESCRIPTION
We had been having some trouble with the Language on some of our BitBar tests, so we contacted support about it, and received the below response.

> It seems that in your project configuration the language parameter is defined as "en-US" ("deviceLanguageCode":"en-US"), while it should be defined as "en_US" (deviceLanguageCode":"en_US") . So the dash needs to be changed to underscore. 

I reviewed our configuration, and found that this plugin had written the language code incorrectly into the configuration.

This PR makes the following changes:

1. When creating/updating configurations, the plugin will use an underscore separator for the device language and country codes.
2. When handling old configurations, to ensure all users don't need to update their configuration file, it will replace the hyphen separator in memory, ensuring the correct formatting will still be sent to BitBar.