### PR TITLE
Make RiC compatible with snippet generator

### DIFF
--- a/src/main/java/com/testdroid/jenkins/PipelineCloudStep.java
+++ b/src/main/java/com/testdroid/jenkins/PipelineCloudStep.java
@@ -14,6 +14,9 @@ import org.jenkinsci.plugins.workflow.steps.StepContextParameter;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import static com.testdroid.jenkins.RunInCloudDescriptorHelper.*;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
 /**
  * Pipeline build step for Bitbar Cloud's Jenkins plugin.
  *
@@ -55,14 +58,7 @@ public class PipelineCloudStep extends AbstractStepImpl {
     private Long frameworkId;
     private APIDevice.OsType osType;
 
-    // these variables are used to create a WaitForResultsBlock
-    private boolean waitForResults;
-    private String testRunStateCheckMethod; // API_CALL, HOOK_URL,
-    private String hookURL;
-    private String waitForResultsTimeout;
-    private String resultsPath;
-    private boolean downloadScreenshots;
-    private boolean forceFinishAfterBreak;
+    private WaitForResultsBlock waitForResultsBlock;
 
     /**
      * Constructor; defined the mandatory parameters to be passed in Pipeline.
@@ -81,7 +77,9 @@ public class PipelineCloudStep extends AbstractStepImpl {
 
     @DataBoundSetter
     public void setTestRunName(String testRunName) {
-        this.testRunName = testRunName;
+        if (isNotBlank(testRunName)) {
+            this.testRunName = testRunName;
+        }
     }
 
     @DataBoundSetter
@@ -91,62 +89,87 @@ public class PipelineCloudStep extends AbstractStepImpl {
 
     @DataBoundSetter
     public void setTestRunner(String testRunner) {
-        this.testRunner = testRunner;
+        if (isNotBlank(testRunner)) {
+            this.testRunner = testRunner;
+        }
     }
 
     @DataBoundSetter
     public void setTestPath(String testPath) {
-        this.testPath = testPath;
+        if (isNotBlank(testPath)) {
+            this.testPath = testPath;
+        }
     }
 
     @DataBoundSetter
     public void setScreenshotsDirectory(String screenshotsDirectory) {
-        this.screenshotsDirectory = screenshotsDirectory;
+        if (isNotBlank(screenshotsDirectory)) {
+            this.screenshotsDirectory = screenshotsDirectory;
+        }
     }
 
     @DataBoundSetter
     public void setKeyValuePairs(String keyValuePairs) {
-        this.keyValuePairs = keyValuePairs;
+        if (isNotBlank(withAnnotation)) {
+            this.keyValuePairs = keyValuePairs;
+        }
     }
 
     @DataBoundSetter
     public void setWithAnnotation(String withAnnotation) {
-        this.withAnnotation = withAnnotation;
+        if (isNotBlank(withAnnotation)) {
+            this.withAnnotation = withAnnotation;
+        }
     }
 
     @DataBoundSetter
     public void setWithoutAnnotation(String withoutAnnotation) {
-        this.withoutAnnotation = withoutAnnotation;
+        if (isNotBlank(withoutAnnotation)) {
+            this.withoutAnnotation = withoutAnnotation;
+        }
     }
 
     @DataBoundSetter
     public void setTestCasesSelect(String testCasesSelect) {
-        this.testCasesSelect = testCasesSelect;
+        if (isNotBlank(testCasesSelect) && !testCasesSelect.equalsIgnoreCase(DEFAULT_TEST_CASES_SELECT)) {
+            this.testCasesSelect = testCasesSelect;
+        }
     }
 
     @DataBoundSetter
     public void setTestCasesValue(String testCasesValue) {
-        this.testCasesValue = testCasesValue;
+        if (isNotBlank(testCasesValue)) {
+            this.testCasesValue = testCasesValue;
+        }
     }
 
     @DataBoundSetter
     public void setDataPath(String dataPath) {
-        this.dataPath = dataPath;
+        if (isNotBlank(dataPath)) {
+            this.dataPath = dataPath;
+        }
     }
 
     @DataBoundSetter
     public void setLanguage(String language) {
-        this.language = language;
+        if (isNotBlank(language) && !language.equals(DEFAULT_LANGUAGE)) {
+            this.language = language;
+        }
+
     }
 
     @DataBoundSetter
     public void setScheduler(String scheduler) {
-        this.scheduler = scheduler.toLowerCase();
+        if (isNotBlank(scheduler) && !scheduler.equalsIgnoreCase(DEFAULT_SCHEDULER)) {
+            this.scheduler = scheduler.toUpperCase();
+        }
     }
 
     @DataBoundSetter
     public void setTestTimeout(String testTimeout) {
-        this.testTimeout = testTimeout;
+        if (isNotBlank(testTimeout)) {
+            this.testTimeout = testTimeout;
+        }
     }
 
     @DataBoundSetter
@@ -170,41 +193,6 @@ public class PipelineCloudStep extends AbstractStepImpl {
     }
 
     @DataBoundSetter
-    public void setWaitForResults(boolean waitForResults) {
-        this.waitForResults = waitForResults;
-    }
-
-    @DataBoundSetter
-    public void setTestRunStateCheckMethod(String testRunStateCheckMethod) {
-        this.testRunStateCheckMethod = testRunStateCheckMethod;
-    }
-
-    @DataBoundSetter
-    public void setHookURL(String hookURL) {
-        this.hookURL = hookURL;
-    }
-
-    @DataBoundSetter
-    public void setWaitForResultsTimeout(String waitForResultsTimeout) {
-        this.waitForResultsTimeout = waitForResultsTimeout;
-    }
-
-    @DataBoundSetter
-    public void setResultsPath(String resultsPath) {
-        this.resultsPath = resultsPath;
-    }
-
-    @DataBoundSetter
-    public void setDownloadScreenshots(boolean downloadScreenshots) {
-        this.downloadScreenshots = downloadScreenshots;
-    }
-
-    @DataBoundSetter
-    public void setForceFinishAfterBreak(boolean forceFinishAfterBreak) {
-        this.forceFinishAfterBreak = forceFinishAfterBreak;
-    }
-
-    @DataBoundSetter
     public void setFrameworkId(Long frameworkId) {
         this.frameworkId = frameworkId;
     }
@@ -214,76 +202,84 @@ public class PipelineCloudStep extends AbstractStepImpl {
         this.osType = osType;
     }
 
+    @DataBoundSetter
+    public void setWaitForResultsBlock(WaitForResultsBlock waitForResultsBlock) {
+        this.waitForResultsBlock = waitForResultsBlock;
+    }
 
-    private String getTestRunName() {
+    public WaitForResultsBlock getWaitForResultsBlock() {
+        return waitForResultsBlock;
+    }
+
+    public String getTestRunName() {
         return testRunName;
     }
 
-    private String getAppPath() {
+    public String getAppPath() {
         return appPath;
     }
 
-    private String getTestPath() {
+    public String getTestPath() {
         return testPath;
     }
 
-    private String getProjectId() {
+    public String getProjectId() {
         return projectId;
     }
 
-    private String getDeviceGroupId() {
+    public String getDeviceGroupId() {
         return deviceGroupId;
     }
 
-    private String getTestRunner() {
+    public String getTestRunner() {
         return testRunner;
     }
 
-    private String getScreenshotsDirectory() {
+    public String getScreenshotsDirectory() {
         return screenshotsDirectory;
     }
 
-    private String getKeyValuePairs() {
+    public String getKeyValuePairs() {
         return keyValuePairs;
     }
 
-    private String getWithAnnotation() {
+    public String getWithAnnotation() {
         return withAnnotation;
     }
 
-    private String getWithoutAnnotation() {
+    public String getWithoutAnnotation() {
         return withoutAnnotation;
     }
 
-    private String getTestCasesSelect() {
-        return testCasesSelect;
+    public String getTestCasesSelect() {
+        return isNotBlank(testCasesSelect) ? testCasesSelect.toUpperCase() : DEFAULT_TEST_CASES_SELECT;
     }
 
-    private String getTestCasesValue() {
+    public String getTestCasesValue() {
         return testCasesValue;
     }
 
-    private String getDataPath() {
+    public String getDataPath() {
         return dataPath;
     }
 
-    private String getLanguage() {
-        return language;
+    public String getLanguage() {
+        return isNotBlank(language) ? language : DEFAULT_LANGUAGE;
     }
 
     public String getScheduler() {
-        return scheduler;
+        return isNotBlank(scheduler) ? scheduler.toUpperCase() : DEFAULT_SCHEDULER;
     }
 
-    private boolean isFailBuildIfThisStepFailed() {
+    public boolean isFailBuildIfThisStepFailed() {
         return failBuildIfThisStepFailed;
     }
 
-    private String getTestTimeout() {
+    public String getTestTimeout() {
         return testTimeout;
     }
 
-    private String getCredentialsId() {
+    public String getCredentialsId() {
         return credentialsId;
     }
 
@@ -295,35 +291,7 @@ public class PipelineCloudStep extends AbstractStepImpl {
         return cloudUIUrl;
     }
 
-    private boolean isWaitForResults() {
-        return waitForResults;
-    }
-
-    private String getTestRunStateCheckMethod() {
-        return testRunStateCheckMethod;
-    }
-
-    private String getHookURL() {
-        return hookURL;
-    }
-
-    private String getWaitForResultsTimeout() {
-        return waitForResultsTimeout;
-    }
-
-    private String getResultsPath() {
-        return resultsPath;
-    }
-
-    private boolean isDownloadScreenshots() {
-        return downloadScreenshots;
-    }
-
-    private boolean isForceFinishAfterBreak() {
-        return forceFinishAfterBreak;
-    }
-
-    private Long getFrameworkId() {
+    public Long getFrameworkId() {
         return this.frameworkId;
     }
 
@@ -332,7 +300,8 @@ public class PipelineCloudStep extends AbstractStepImpl {
     }
 
     @Extension
-    public static final class DescriptorImpl extends AbstractStepDescriptorImpl {
+    public static final class DescriptorImpl extends AbstractStepDescriptorImpl implements RunInCloudDescriptorHelper {
+
         public DescriptorImpl() {
             super(CloudStepExecution.class);
         }
@@ -348,7 +317,6 @@ public class PipelineCloudStep extends AbstractStepImpl {
         }
     }
 
-
     public static final class CloudStepExecution extends AbstractSynchronousNonBlockingStepExecution<Boolean> {
 
         private static final long serialVersionUID = 1;
@@ -363,25 +331,13 @@ public class PipelineCloudStep extends AbstractStepImpl {
         private transient Launcher launcher;
 
         @StepContextParameter
-        private transient Run<?,?> run;
+        private transient Run<?, ?> run;
 
         @StepContextParameter
         private transient FilePath workspace;
 
         @Override
-        protected Boolean run() throws Exception {
-            WaitForResultsBlock waitForResultsBlock = null;
-            if (step.isWaitForResults()) {
-                waitForResultsBlock = new WaitForResultsBlock(
-                        step.getTestRunStateCheckMethod(),
-                        step.getHookURL(),
-                        step.getWaitForResultsTimeout(),
-                        step.getResultsPath(),
-                        step.isDownloadScreenshots(),
-                        step.isForceFinishAfterBreak()
-                );
-            }
-
+        protected Boolean run() {
             RunInCloudBuilder builder = new RunInCloudBuilder(
                     step.getProjectId(),
                     step.getAppPath(),
@@ -399,7 +355,7 @@ public class PipelineCloudStep extends AbstractStepImpl {
                     step.getTestCasesSelect(),
                     step.getTestCasesValue(),
                     step.isFailBuildIfThisStepFailed(),
-                    waitForResultsBlock,
+                    step.getWaitForResultsBlock(),
                     step.getTestTimeout(),
                     step.getCredentialsId(),
                     step.getCloudUrl(),

--- a/src/main/java/com/testdroid/jenkins/RunInCloudDescriptorHelper.java
+++ b/src/main/java/com/testdroid/jenkins/RunInCloudDescriptorHelper.java
@@ -1,0 +1,182 @@
+package com.testdroid.jenkins;
+
+import com.testdroid.api.APIException;
+import com.testdroid.api.APIListResource;
+import com.testdroid.api.dto.Context;
+import com.testdroid.api.filter.BooleanFilterEntry;
+import com.testdroid.api.filter.StringFilterEntry;
+import com.testdroid.api.model.*;
+import com.testdroid.jenkins.model.TestRunStateCheckMethod;
+import com.testdroid.jenkins.utils.AndroidLocale;
+import com.testdroid.jenkins.utils.LocaleUtil;
+import com.testdroid.jenkins.utils.TestdroidApiUtil;
+import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
+import org.kohsuke.stapler.QueryParameter;
+
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import static com.testdroid.api.dto.Operand.EQ;
+import static com.testdroid.api.model.APIDevice.OsType.UNDEFINED;
+import static com.testdroid.dao.repository.dto.MappingKey.*;
+import static com.testdroid.jenkins.Messages.DEFINE_FRAMEWORK;
+import static com.testdroid.jenkins.Messages.DEFINE_OS_TYPE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.Integer.MAX_VALUE;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Locale.US;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+public interface RunInCloudDescriptorHelper {
+
+    Logger LOGGER = Logger.getLogger(RunInCloudDescriptorHelper.class.getSimpleName());
+
+    List<String> PAID_ROLES = unmodifiableList(asList("PRIORITY_SILVER", "PRIORITY_GOLD", "PRIORITY_PLATINUM"));
+
+    String DEFAULT_SCHEDULER = APITestRunConfig.Scheduler.PARALLEL.name();
+
+    String DEFAULT_TEST_CASES_SELECT = APITestRunConfig.LimitationType.PACKAGE.name();
+
+    String DEFAULT_LANGUAGE = LocaleUtil.formatLangCode(US);
+
+    ListBoxModel.Option EMPTY_OPTION = new ListBoxModel.Option(EMPTY, EMPTY);
+
+    default boolean isAuthenticated() {
+        return TestdroidApiUtil.getGlobalApiClient().isAuthenticated();
+    }
+
+    //Do not remove, is used in config.jelly
+    default boolean isPaidUser() {
+        boolean result = false;
+        if (isAuthenticated()) {
+            try {
+                Date now = new Date();
+                result = Arrays.stream(TestdroidApiUtil.getGlobalApiClient().getUser().getRoles()).
+                        anyMatch(r -> PAID_ROLES.contains(r.getName())
+                                && (r.getExpireTime() == null || r.getExpireTime().after(now)));
+            } catch (APIException e) {
+                LOGGER.log(Level.WARNING, Messages.ERROR_API());
+            }
+        }
+        return result;
+    }
+
+    default ListBoxModel doFillProjectIdItems() {
+        ListBoxModel projects = new ListBoxModel();
+        try {
+            APIUser user = TestdroidApiUtil.getGlobalApiClient().getUser();
+            final Context<APIProject> context = new Context(APIProject.class, 0, MAX_VALUE, EMPTY, EMPTY);
+            final APIListResource<APIProject> projectResource = user.getProjectsResource(context);
+            for (APIProject project : projectResource.getEntity().getData()) {
+                projects.add(project.getName(), project.getId().toString());
+            }
+        } catch (APIException e) {
+            LOGGER.log(Level.WARNING, Messages.ERROR_API());
+        }
+        return projects;
+    }
+
+    default ListBoxModel doFillOsTypeItems() {
+        ListBoxModel osTypes = new ListBoxModel();
+        osTypes.addAll(Arrays.stream(APIDevice.OsType.values())
+                .map(t -> new ListBoxModel.Option(t.getDisplayName(), t.name()))
+                .collect(Collectors.toList()));
+        return osTypes;
+    }
+
+    default FormValidation doCheckOsType(@QueryParameter APIDevice.OsType value) {
+        return value == UNDEFINED ? FormValidation.error(DEFINE_OS_TYPE()) : FormValidation.ok();
+    }
+
+    default ListBoxModel doFillSchedulerItems() {
+        ListBoxModel schedulers = new ListBoxModel();
+        schedulers.add(Messages.SCHEDULER_PARALLEL(), APITestRunConfig.Scheduler.PARALLEL.name());
+        schedulers.add(Messages.SCHEDULER_SERIAL(), APITestRunConfig.Scheduler.SERIAL.name());
+        schedulers.add(Messages.SCHEDULER_SINGLE(), APITestRunConfig.Scheduler.SINGLE.name());
+        return schedulers;
+    }
+
+    default ListBoxModel doFillDeviceGroupIdItems() {
+        ListBoxModel deviceGroups = new ListBoxModel();
+        try {
+            APIUser user = TestdroidApiUtil.getGlobalApiClient().getUser();
+            final Context<APIDeviceGroup> context = new Context(APIDeviceGroup.class, 0, MAX_VALUE, EMPTY, EMPTY);
+            context.setExtraParams(Collections.singletonMap(WITH_PUBLIC, TRUE));
+            final APIListResource<APIDeviceGroup> deviceGroupResource = user.getDeviceGroupsResource(context);
+            for (APIDeviceGroup deviceGroup : deviceGroupResource.getEntity().getData()) {
+                deviceGroups.add(String.format("%s (%d device(s))", deviceGroup.getDisplayName(),
+                        deviceGroup.getDeviceCount()), deviceGroup.getId().toString());
+            }
+        } catch (APIException e) {
+            LOGGER.log(Level.WARNING, Messages.ERROR_API());
+        }
+        return deviceGroups;
+    }
+
+    default ListBoxModel doFillLanguageItems() {
+        ListBoxModel language = new ListBoxModel();
+        for (Locale locale : AndroidLocale.LOCALES) {
+            String langDisplay = String.format("%s (%s)", locale.getDisplayLanguage(),
+                    locale.getDisplayCountry());
+            String langCode = LocaleUtil.formatLangCode(locale);
+            language.add(langDisplay, langCode);
+        }
+        return language;
+    }
+
+    default ListBoxModel doFillTestCasesSelectItems() {
+        ListBoxModel testCases = new ListBoxModel();
+        String value;
+        for (APITestRunConfig.LimitationType limitationType : APITestRunConfig.LimitationType.values()) {
+            value = limitationType.name();
+            testCases.add(value.toLowerCase(), value);
+        }
+        return testCases;
+    }
+
+    default ListBoxModel doFillTestRunStateCheckMethodItems() {
+        ListBoxModel items = new ListBoxModel();
+        for (TestRunStateCheckMethod method : TestRunStateCheckMethod.values()) {
+            items.add(method.name(), method.name());
+        }
+        return items;
+    }
+
+    default ListBoxModel doFillFrameworkIdItems(@QueryParameter APIDevice.OsType osType) {
+        ListBoxModel frameworks = new ListBoxModel();
+        frameworks.add(EMPTY_OPTION);
+        if (osType != UNDEFINED) {
+            try {
+                APIUser user = TestdroidApiUtil.getGlobalApiClient().getUser();
+                final Context<APIFramework> context = new Context(APIFramework.class, 0, MAX_VALUE, EMPTY, EMPTY);
+                context.addFilter(new StringFilterEntry(OS_TYPE, EQ, osType.name()));
+                context.addFilter(new BooleanFilterEntry(FOR_PROJECTS, EQ, TRUE));
+                context.addFilter(new BooleanFilterEntry(CAN_RUN_FROM_UI, EQ, TRUE));
+                final APIListResource<APIFramework> availableFrameworksResource = user
+                        .getAvailableFrameworksResource(context);
+                frameworks.addAll(availableFrameworksResource.getEntity().getData().stream().map(f ->
+                        new ListBoxModel.Option(f.getName(), f.getId().toString())).collect(Collectors.toList()));
+            } catch (APIException e) {
+                LOGGER.log(Level.WARNING, Messages.ERROR_API());
+            }
+        }
+        return frameworks;
+    }
+
+    default FormValidation doCheckFrameworkId(@QueryParameter String value) {
+        return parseLong(value).isPresent() ? FormValidation.ok() : FormValidation.error(DEFINE_FRAMEWORK());
+    }
+
+    default Optional<Long> parseLong(String value) {
+        try {
+            return Optional.of(Long.parseLong(value));
+        } catch (NumberFormatException nfe) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/src/main/java/com/testdroid/jenkins/WaitForResultsBlock.java
+++ b/src/main/java/com/testdroid/jenkins/WaitForResultsBlock.java
@@ -2,11 +2,13 @@ package com.testdroid.jenkins;
 
 import com.testdroid.jenkins.model.TestRunStateCheckMethod;
 import hudson.Extension;
-import hudson.model.*;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.math.NumberUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class WaitForResultsBlock implements Describable<WaitForResultsBlock> {
 
@@ -15,48 +17,42 @@ public class WaitForResultsBlock implements Describable<WaitForResultsBlock> {
      */
     @SuppressWarnings("unchecked")
     public Descriptor<WaitForResultsBlock> getDescriptor() {
-        return Jenkins.getActiveInstance().getDescriptorOrDie(getClass());
+        return Jenkins.getInstance().getDescriptorOrDie(getClass());
     }
 
-    boolean downloadScreenshots;
+    private boolean downloadScreenshots;
 
-    boolean forceFinishAfterBreak;
+    private boolean forceFinishAfterBreak;
 
-    String hookURL;
+    private String hookURL;
 
-    String resultsPath;
+    private String resultsPath;
 
-    TestRunStateCheckMethod testRunStateCheckMethod;
+    private TestRunStateCheckMethod testRunStateCheckMethod;
 
-    Integer waitForResultsTimeout;
+    private Integer waitForResultsTimeout;
 
     @DataBoundConstructor
-    public WaitForResultsBlock(String testRunStateCheckMethod, String hookURL, String waitForResultsTimeout,
-            String resultsPath, boolean downloadScreenshots, boolean forceFinishAfterBreak) {
-        this.testRunStateCheckMethod = (StringUtils.isBlank(testRunStateCheckMethod)) ? TestRunStateCheckMethod.HOOK_URL :
-        TestRunStateCheckMethod.valueOf(testRunStateCheckMethod.toUpperCase());
-        this.hookURL = hookURL;
-        this.resultsPath = resultsPath;
-        this.downloadScreenshots = downloadScreenshots;
-        this.forceFinishAfterBreak = forceFinishAfterBreak;
-        this.waitForResultsTimeout = NumberUtils.toInt(waitForResultsTimeout);
+    public WaitForResultsBlock(TestRunStateCheckMethod testRunStateCheckMethod) {
+        this.testRunStateCheckMethod = testRunStateCheckMethod;
     }
 
     public String getHookURL() {
         return hookURL;
     }
 
+    @DataBoundSetter
     public void setHookURL(String hookURL) {
-        this.hookURL = hookURL;
+        if (isNotBlank(hookURL)) {
+            this.hookURL = hookURL;
+        }
     }
 
     public Integer getWaitForResultsTimeout() {
-        if (waitForResultsTimeout == null) {
-            waitForResultsTimeout = 0;
-        }
-        return waitForResultsTimeout;
+        return waitForResultsTimeout != null ? waitForResultsTimeout : 0;
     }
 
+    @DataBoundSetter
     public void setWaitForResultsTimeout(Integer waitForResultsTimeout) {
         this.waitForResultsTimeout = waitForResultsTimeout;
     }
@@ -65,25 +61,27 @@ public class WaitForResultsBlock implements Describable<WaitForResultsBlock> {
         return resultsPath;
     }
 
+    @DataBoundSetter
     public void setResultsPath(String resultsPath) {
-        this.resultsPath = resultsPath;
+        if (isNotBlank(resultsPath)) {
+            this.resultsPath = resultsPath;
+        }
     }
 
     public boolean isDownloadScreenshots() {
         return downloadScreenshots;
     }
 
+    @DataBoundSetter
     public void setDownloadScreenshots(boolean downloadScreenshots) {
         this.downloadScreenshots = downloadScreenshots;
     }
 
     public TestRunStateCheckMethod getTestRunStateCheckMethod() {
-        if (testRunStateCheckMethod == null) {
-            testRunStateCheckMethod = TestRunStateCheckMethod.HOOK_URL;
-        }
-        return testRunStateCheckMethod;
+        return testRunStateCheckMethod != null ? testRunStateCheckMethod : TestRunStateCheckMethod.HOOK_URL;
     }
 
+    @DataBoundSetter
     public void setTestRunStateCheckMethod(TestRunStateCheckMethod testRunStateCheckMethod) {
         this.testRunStateCheckMethod = testRunStateCheckMethod;
     }
@@ -92,12 +90,14 @@ public class WaitForResultsBlock implements Describable<WaitForResultsBlock> {
         return forceFinishAfterBreak;
     }
 
+    @DataBoundSetter
     public void setForceFinishAfterBreak(boolean forceFinishAfterBreak) {
         this.forceFinishAfterBreak = forceFinishAfterBreak;
     }
 
     @Extension
     public static final class DescriptorImpl extends Descriptor<WaitForResultsBlock> {
+
         public DescriptorImpl() {
             super(WaitForResultsBlock.class);
         }

--- a/src/main/resources/com/testdroid/jenkins/PipelineCloudStep/config.jelly
+++ b/src/main/resources/com/testdroid/jenkins/PipelineCloudStep/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
+    <st:include class="com.testdroid.jenkins.RunInCloudBuilder" page="config.jelly" />
+</j:jelly>

--- a/src/main/resources/com/testdroid/jenkins/RunInCloudBuilder/config.jelly
+++ b/src/main/resources/com/testdroid/jenkins/RunInCloudBuilder/config.jelly
@@ -42,7 +42,7 @@
             <f:entry title="${%Scheduling}" field="scheduler">
                 <f:select default="PARALLEL"/>
             </f:entry>
-            <f:entry field="clusterId" title="${%Device group}">
+            <f:entry field="deviceGroupId" title="${%Device group}">
                 <f:select/>
             </f:entry>
             <f:entry field="language" title="${%Device language}">


### PR DESCRIPTION
Summary of changes:
* Make `PipelineCloudStep` usable by Snippet generator. For not generating default(sometimes '') values we have to use tricks like:
```
@DataBoundSetter
public void setWithoutAnnotation(String withoutAnnotation) {
    if(StringUtils.isNotBlank(withoutAnnotation)) {
        this.withoutAnnotation = withoutAnnotation;
    }
}
```
* Handling of `WaitForResultsBlock` was rewritten(Also neede for Snippet generator), I decide to lost backward compatibility as we support the pipeline not so long, so should be not many users use this `WaitForResultsBlock`

* Change misleading `clusterId` to `deviceGroupId` with backward compatibility with already exists config.xml