### PR TITLE
Add support for passing the API Key as the username

### DIFF
--- a/src/main/java/com/testdroid/jenkins/utils/TestdroidApiUtil.java
+++ b/src/main/java/com/testdroid/jenkins/utils/TestdroidApiUtil.java
@@ -38,56 +38,56 @@ public class TestdroidApiUtil {
     public static ApiClientAdapter createNewApiClient(MachineIndependentTask machineIndependentTask) {
         APIClient apiClient;
 
-	    if (StringUtils.isNotEmpty(machineIndependentTask.password)) {
+        if (StringUtils.isNotEmpty(machineIndependentTask.password)) {
             // If the password is set, try username and password authentication
-	        if (machineIndependentTask.isProxy) {
-	            HttpHost proxy = machineIndependentTask.proxyPort != null ?
-	                    new HttpHost(machineIndependentTask.proxyHost,
-	                            machineIndependentTask.proxyPort, "http") :
-	                    new HttpHost(machineIndependentTask.proxyHost);
+            if (machineIndependentTask.isProxy) {
+                HttpHost proxy = machineIndependentTask.proxyPort != null ?
+                        new HttpHost(machineIndependentTask.proxyHost,
+                                machineIndependentTask.proxyPort, "http") :
+                        new HttpHost(machineIndependentTask.proxyHost);
 
-	            apiClient = StringUtils.isBlank(machineIndependentTask.proxyUser) ?
-	                    new DefaultAPIClient(machineIndependentTask.cloudUrl,
-	                            machineIndependentTask.user,
-	                            machineIndependentTask.password, proxy,
-	                            machineIndependentTask.noCheckCertificate) :
-	                    new DefaultAPIClient(machineIndependentTask.cloudUrl,
-	                            machineIndependentTask.user,
-	                            machineIndependentTask.password, proxy,
-	                            machineIndependentTask.proxyUser,
-	                            machineIndependentTask.proxyPassword,
-	                            machineIndependentTask.noCheckCertificate);
-	        } else {
-	            apiClient = new DefaultAPIClient(machineIndependentTask.cloudUrl,
-	                    machineIndependentTask.user,
-	                    machineIndependentTask.password,
-	                    machineIndependentTask.noCheckCertificate);
-	        } 
+                apiClient = StringUtils.isBlank(machineIndependentTask.proxyUser) ?
+                        new DefaultAPIClient(machineIndependentTask.cloudUrl,
+                                machineIndependentTask.user,
+                                machineIndependentTask.password, proxy,
+                                machineIndependentTask.noCheckCertificate) :
+                        new DefaultAPIClient(machineIndependentTask.cloudUrl,
+                                machineIndependentTask.user,
+                                machineIndependentTask.password, proxy,
+                                machineIndependentTask.proxyUser,
+                                machineIndependentTask.proxyPassword,
+                                machineIndependentTask.noCheckCertificate);
+            } else {
+                apiClient = new DefaultAPIClient(machineIndependentTask.cloudUrl,
+                        machineIndependentTask.user,
+                        machineIndependentTask.password,
+                        machineIndependentTask.noCheckCertificate);
+            } 
         } else {
             // Try the username as an apikey
-	        if (machineIndependentTask.isProxy) {
-	            HttpHost proxy = machineIndependentTask.proxyPort != null ?
-	                    new HttpHost(machineIndependentTask.proxyHost,
-	                            machineIndependentTask.proxyPort, "http") :
-	                    new HttpHost(machineIndependentTask.proxyHost);
+            if (machineIndependentTask.isProxy) {
+                HttpHost proxy = machineIndependentTask.proxyPort != null ?
+                        new HttpHost(machineIndependentTask.proxyHost,
+                                machineIndependentTask.proxyPort, "http") :
+                        new HttpHost(machineIndependentTask.proxyHost);
 
-	            apiClient = StringUtils.isBlank(machineIndependentTask.proxyUser) ?
-	                    new APIKeyClient(machineIndependentTask.cloudUrl,
-	                            machineIndependentTask.user,
-	                            proxy,
-	                            machineIndependentTask.noCheckCertificate) :
-	                    new APIKeyClient(machineIndependentTask.cloudUrl,
-	                            machineIndependentTask.user,
-	                            proxy,
-	                            machineIndependentTask.proxyUser,
-	                            machineIndependentTask.proxyPassword,
-	                            machineIndependentTask.noCheckCertificate);
-	        } else {
-	            apiClient = new APIKeyClient(machineIndependentTask.cloudUrl,
-	                    machineIndependentTask.user,
-	                    machineIndependentTask.noCheckCertificate);
-	        }
-	    }
+                apiClient = StringUtils.isBlank(machineIndependentTask.proxyUser) ?
+                        new APIKeyClient(machineIndependentTask.cloudUrl,
+                                machineIndependentTask.user,
+                                proxy,
+                                machineIndependentTask.noCheckCertificate) :
+                        new APIKeyClient(machineIndependentTask.cloudUrl,
+                                machineIndependentTask.user,
+                                proxy,
+                                machineIndependentTask.proxyUser,
+                                machineIndependentTask.proxyPassword,
+                                machineIndependentTask.noCheckCertificate);
+            } else {
+                apiClient = new APIKeyClient(machineIndependentTask.cloudUrl,
+                        machineIndependentTask.user,
+                        machineIndependentTask.noCheckCertificate);
+            }
+        }
         return new ApiClientAdapter(apiClient);
     }
 
@@ -98,35 +98,35 @@ public class TestdroidApiUtil {
         boolean dontCheckCert = settings.getNoCheckCertificate();
         APIClient apiClient;
 
-	    if (StringUtils.isNotEmpty(password)) {
+        if (StringUtils.isNotEmpty(password)) {
             // If the password is set, try username and password authentication
-	        if (settings.getIsProxy()) {
-	            HttpHost proxy = settings.getProxyPort() != null ?
-	                    new HttpHost(settings.getProxyHost(), settings.getProxyPort(), "http") :
-	                    new HttpHost(settings.getProxyHost());
+            if (settings.getIsProxy()) {
+                HttpHost proxy = settings.getProxyPort() != null ?
+                        new HttpHost(settings.getProxyHost(), settings.getProxyPort(), "http") :
+                        new HttpHost(settings.getProxyHost());
 
-	            apiClient = StringUtils.isBlank(settings.getProxyUser()) ?
-	                    new DefaultAPIClient(cloudURL, email, password, proxy, dontCheckCert) :
-	                    new DefaultAPIClient(cloudURL, email, password, proxy,
-	                            settings.getProxyUser(), settings.getProxyPassword(), dontCheckCert);
-	        } else {
-	            apiClient = new DefaultAPIClient(cloudURL, email, password, dontCheckCert);
-	        }
+                apiClient = StringUtils.isBlank(settings.getProxyUser()) ?
+                        new DefaultAPIClient(cloudURL, email, password, proxy, dontCheckCert) :
+                        new DefaultAPIClient(cloudURL, email, password, proxy,
+                                settings.getProxyUser(), settings.getProxyPassword(), dontCheckCert);
+            } else {
+                apiClient = new DefaultAPIClient(cloudURL, email, password, dontCheckCert);
+            }
         } else {
             // Try the username as an apikey
             if (settings.getIsProxy()) {
-	            HttpHost proxy = settings.getProxyPort() != null ?
-	                    new HttpHost(settings.getProxyHost(), settings.getProxyPort(), "http") :
-	                    new HttpHost(settings.getProxyHost());
+                HttpHost proxy = settings.getProxyPort() != null ?
+                        new HttpHost(settings.getProxyHost(), settings.getProxyPort(), "http") :
+                        new HttpHost(settings.getProxyHost());
 
-	            apiClient = StringUtils.isBlank(settings.getProxyUser()) ?
-	                    new APIKeyClient(cloudURL, email, dontCheckCert) :
-	                    new APIKeyClient(cloudURL, email, proxy,
-	                            settings.getProxyUser(), settings.getProxyPassword(), dontCheckCert);
-	        } else {
-	            apiClient = new APIKeyClient(cloudURL, email, dontCheckCert);
-	        }
-	    }
+                apiClient = StringUtils.isBlank(settings.getProxyUser()) ?
+                        new APIKeyClient(cloudURL, email, dontCheckCert) :
+                        new APIKeyClient(cloudURL, email, proxy,
+                                settings.getProxyUser(), settings.getProxyPassword(), dontCheckCert);
+            } else {
+                apiClient = new APIKeyClient(cloudURL, email, dontCheckCert);
+            }
+        }
         return new ApiClientAdapter(apiClient);
     }
 }

--- a/src/main/java/com/testdroid/jenkins/utils/TestdroidApiUtil.java
+++ b/src/main/java/com/testdroid/jenkins/utils/TestdroidApiUtil.java
@@ -38,7 +38,7 @@ public class TestdroidApiUtil {
     public static ApiClientAdapter createNewApiClient(MachineIndependentTask machineIndependentTask) {
         APIClient apiClient;
 
-	    if (machineIndependentTask.password != null && !machineIndependentTask.password.isEmpty()) {
+	    if (StringUtils.isNotEmpty(machineIndependentTask.password)) {
             // If the password is set, try username and password authentication
 	        if (machineIndependentTask.isProxy) {
 	            HttpHost proxy = machineIndependentTask.proxyPort != null ?
@@ -63,7 +63,7 @@ public class TestdroidApiUtil {
 	                    machineIndependentTask.password,
 	                    machineIndependentTask.noCheckCertificate);
 	        } 
-	    } else {
+        } else {
             // Try the username as an apikey
 	        if (machineIndependentTask.isProxy) {
 	            HttpHost proxy = machineIndependentTask.proxyPort != null ?
@@ -98,7 +98,7 @@ public class TestdroidApiUtil {
         boolean dontCheckCert = settings.getNoCheckCertificate();
         APIClient apiClient;
 
-	    if (password != null && !password.isEmpty()) {
+	    if (StringUtils.isNotEmpty(password)) {
             // If the password is set, try username and password authentication
 	        if (settings.getIsProxy()) {
 	            HttpHost proxy = settings.getProxyPort() != null ?
@@ -112,7 +112,7 @@ public class TestdroidApiUtil {
 	        } else {
 	            apiClient = new DefaultAPIClient(cloudURL, email, password, dontCheckCert);
 	        }
-	    } else {
+        } else {
             // Try the username as an apikey
             if (settings.getIsProxy()) {
 	            HttpHost proxy = settings.getProxyPort() != null ?


### PR DESCRIPTION
This patch adds support for passing the APIKey by setting it as the user/email in the Jenkins configuration. This is the same style as shown on the BitBar authentication webpage curl example:

https://support.smartbear.com/bitbar/docs/api/authentication.html

curl -u <api-key>: https://cloud.bitbar.com/api/me
